### PR TITLE
[usersadapter,vinadapter] Create path for adapters' files

### DIFF
--- a/plugins/usersadapter/usersadapter.go
+++ b/plugins/usersadapter/usersadapter.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	log "github.com/sirupsen/logrus"
 
@@ -73,6 +74,10 @@ func New(configJSON json.RawMessage) (adapter dataprovider.DataAdapter, err erro
 		log.Warnf("Can't read users: %s. Empty users will be used", err)
 
 		localAdapter.users = make([]string, 0)
+
+		if err = os.MkdirAll(filepath.Dir(localAdapter.config.FilePath), 0o755); err != nil {
+			return nil, aoserrors.Wrap(err)
+		}
 	}
 
 	log.WithField("users", localAdapter.users).Debug("Users adapter")

--- a/plugins/vinadapter/vinadapter.go
+++ b/plugins/vinadapter/vinadapter.go
@@ -21,6 +21,8 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"math/rand"
+	"os"
+	"path/filepath"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -72,6 +74,10 @@ func New(configJSON json.RawMessage) (adapter dataprovider.DataAdapter, err erro
 		vin = generateVIN()
 
 		log.Warnf("Can't read VIN: %s. Generate new one: %s", err, string(vin))
+
+		if err = os.MkdirAll(filepath.Dir(localAdapter.config.FilePath), 0o755); err != nil {
+			return nil, aoserrors.Wrap(err)
+		}
 
 		if err = ioutil.WriteFile(localAdapter.config.FilePath, vin, 0o600); err != nil {
 			return nil, aoserrors.Wrap(err)


### PR DESCRIPTION
If path not exist, VIS fails.

Signed-off-by: Oleksandr Grytsov <oleksandr_grytsov@epam.com>