### PR TITLE
Fix broken WebSocket connection inside the 'renesassimulatoradapter'

### DIFF
--- a/plugins/renesassimulatoradapter/renesassimulatoradapter.go
+++ b/plugins/renesassimulatoradapter/renesassimulatoradapter.go
@@ -95,6 +95,9 @@ func New(configJSON json.RawMessage) (adapter dataprovider.DataAdapter, err erro
 	localAdapter.upgrader = websocket.Upgrader{
 		ReadBufferSize:  kbSize,
 		WriteBufferSize: kbSize,
+		CheckOrigin: func(r *http.Request) bool {
+			return true
+		},
 	}
 
 	serveMux := http.NewServeMux()


### PR DESCRIPTION
Issue description:

After update of the used version of the 'gorilla/websocket' from v1.4.2 to v1.5.0 the following change was added to the documentation:

"The deprecated package-level Upgrade function does not perform origin checking. The application is responsible for checking the Origin header before calling the Upgrade function."

It means, that we should adapt in order preserve the WebSocket connection between the 'renesassimulatoradapter' and the 'Renesas simulation'.

------------------------

Fix content:

- Added custom 'CheckOrigin' function to the websocket.Upgrader

------------------------

Verification:

- Without the fix we get the following error on attempt to connect 'Renesas simulation' to the 'renesassimulatoradapter':

ERRO[2022-10-20 11:53:31.231] Can't make websocket connection: websocket: request origin not allowed by Upgrader.CheckOrigin

- After application of the fix connection is successful again.

------------------------

Signed-off-by: Vladyslav Goncharuk [Vladyslav_Goncharuk@epam.com](mailto:Vladyslav_Goncharuk@epam.com)